### PR TITLE
fixing pydantic validation error: includes_section.community_support

### DIFF
--- a/src/kodekloud_downloader/models/course.py
+++ b/src/kodekloud_downloader/models/course.py
@@ -40,7 +40,7 @@ class IncludesSection(BaseModel):
     quiz_lessons: bool
     quiz_lesson_count: int
     mock_exams: bool
-    community_support: bool
+    community_support: Optional[bool] = None
     hours_of_video: int
 
 


### PR DESCRIPTION
hi, its a quick and simple fix for pydantic validation error

```
Enter the courses you want to select (Multiple courses can be passes using this format 1,6-9,10-11): 1
Traceback (most recent call last):
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/bin/kodekloud", line 8, in <module>
    sys.exit(kodekloud())
             ^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/kodekloud_downloader/cli.py", line 69, in dl
    download_course(
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/kodekloud_downloader/main.py", line 126, in download_course
    fetch_course_detail(course.slug) if isinstance(course, Course) else course
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/kodekloud_downloader/models/helper.py", line 36, in fetch_course_detail
    return CourseDetail(**data)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan/Projects/learning/kodekloud-dl/.venv/lib/python3.12/site-packages/pydantic/main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for CourseDetail
includes_section.community_support
  Field required [type=missing, input_value={'modules_count': 17, 'le...course_duration': 76887}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```