### PR TITLE
 Removed community_support as it no longer exists in the schema, added course_duration

### DIFF
--- a/src/kodekloud_downloader/models/course.py
+++ b/src/kodekloud_downloader/models/course.py
@@ -40,8 +40,8 @@ class IncludesSection(BaseModel):
     quiz_lessons: bool
     quiz_lesson_count: int
     mock_exams: bool
-    community_support: Optional[bool] = None
     hours_of_video: int
+    course_duration: int
 
 
 class CourseDetail(BaseModel):


### PR DESCRIPTION
Description

    Removed the community_support field as it is no longer part of the schema.
    Added support for the course_duration field to align with the updated schema.

Issue Fixed

Fixes [#89](https://github.com/debakarr/kodekloud-downloader/issues/89).
Next Steps

A new release of the package will be required to ensure the changes are reflected on PyPI.