### PR TITLE
Fix Authorisation and Bearer Headers

### DIFF
--- a/src/kodekloud_downloader/main.py
+++ b/src/kodekloud_downloader/main.py
@@ -117,7 +117,7 @@ def download_course(
     """
     session = requests.Session()
     session_token = parse_token(cookie)
-    headers = {"authorization": f"bearer {session_token}"}
+    headers = {"Authorization": f"Bearer {session_token}"}
     params = {
         "course_id": course.id,
     }


### PR DESCRIPTION
Lowercase Authorisation and Bearer headers is a bug, causing 401 unauthorised despite of a valid seesion-token