### PR TITLE
fix: sanitize quiz filenames for Windows compatibility

### DIFF
--- a/src/kodekloud_downloader/helpers.py
+++ b/src/kodekloud_downloader/helpers.py
@@ -85,6 +85,60 @@ def select_courses(courses: List[Course]) -> List[Course]:
     return user_selected_courses
 
 
+# Characters not allowed in Windows filenames
+_WINDOWS_RESERVED_CHARS = set('\\/:*?"<>|')
+# Reserved names on Windows (case-insensitive, with/without extension)
+_WINDOWS_RESERVED_NAMES = {
+    "con",
+    "prn",
+    "aux",
+    "nul",
+    "com1",
+    "com2",
+    "com3",
+    "com4",
+    "com5",
+    "com6",
+    "com7",
+    "com8",
+    "com9",
+    "lpt1",
+    "lpt2",
+    "lpt3",
+    "lpt4",
+    "lpt5",
+    "lpt6",
+    "lpt7",
+    "lpt8",
+    "lpt9",
+}
+
+
+def sanitize_filename(name: str, max_length: int = 100) -> str:
+    """Sanitize a string for use as a filename component.
+
+    Removes or replaces characters that are invalid across platforms,
+    trims whitespace, and truncates to ``max_length``.
+
+    :param name: The raw string to sanitize.
+    :param max_length: Maximum allowed length (default 100).
+    :return: A safe filename string.
+    """
+    # Replace invalid characters with a safe alternative
+    safe = "".join("_" if c in _WINDOWS_RESERVED_CHARS else c for c in name)
+    # Collapse multiple underscores
+    while "__" in safe:
+        safe = safe.replace("__", "_")
+    # Trim leading/trailing whitespace and dots
+    safe = safe.strip(". ")
+    # Truncate
+    safe = safe[:max_length].rstrip(". ")
+    # Handle empty result or reserved names
+    if not safe or safe.lower().rstrip(".") in _WINDOWS_RESERVED_NAMES:
+        safe = "_"
+    return safe
+
+
 def normalize_name(name: str) -> str:
     """
     Remove punctuation from a string.

--- a/src/kodekloud_downloader/main.py
+++ b/src/kodekloud_downloader/main.py
@@ -13,6 +13,7 @@ from kodekloud_downloader.helpers import (
     download_video,
     is_normal_content,
     normalize_name,
+    sanitize_filename,
 )
 from kodekloud_downloader.models.course import CourseDetail
 from kodekloud_downloader.models.courses import Course
@@ -69,7 +70,8 @@ def download_quiz(output_dir: Union[str, Path], sep: bool) -> None:
                 )
 
         if sep and quiz_name:
-            output_file = Path(output_dir) / f"{quiz_name.replace('/', '')}.md"
+            safe_name = sanitize_filename(quiz_name)
+            output_file = Path(output_dir) / f"{safe_name}.md"
             markdown_text = "\n".join(quiz_markdown)
 
             with open(output_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Fixes #69 and #65. Quiz names can contain characters invalid on Windows (\?\, \:\, \*\, etc.). Adds \sanitize_filename()\ helper and uses it for quiz file output.